### PR TITLE
feat: proxy url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ DEVELOPER_ID=00000 # Please replace with your Developer-ID
 #PATH_DOWNLOAD=/path/to/download # Optional [default: "."]
 #PATH_LOG=/path/to/log # Optional [default: "."]
 #PATH_VENDOR=/path/to/vendor # Optional [default: "vendor"]
+#PROXY_URL=http://my.pro.xy:1234 # Optional [default: null]
 
 # Warning:
 #  Docker interprets double quotes " literally, use single quotes ' instead.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This demo intends to simplify the transition and reduce implementation time.
   -m size               Allocate provided Bytes of memory and download object in-memory (optional, max: 10485760 Bytes), cf. Download modes
   -e extension          Set filename extension of downloaded content [default: "txt"]
   -p password           Password for certificate [default: "123456"]
+  -y proxy              Proxy URL for communucation with the OTTER server (optional, by default no proxy is being set within Otto)
   -f                    Force file overwriting [default: false]
 ```
 
@@ -51,7 +52,7 @@ You need the official ELSTER Otto library and header files. Download the ERiC pa
 > The ERiC package, especially the included there libraries are subject to a separate license agreement (presented before download in the ELSTER developer area and included in the ERiC package itself).
 
 > [!TIP]  
-> Choose the right library for the platform you compile and run on. Recommended ERiC version to use: 41.2
+> Choose the right library for the platform you compile and run on. Recommended Otto version to use: 41.2 with eSigner 60.0.1.2
 
 ## Compile
 


### PR DESCRIPTION
- Add option `-y` for setting a proxy url to use while communicating with the OTTER servers
- Add `PROXY_URL` environment variable (`-y` overrides it)

> [!NOTE]  
> By default no proxy is being used within Otto.